### PR TITLE
コメントの非同期通信の実装

### DIFF
--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,0 +1,15 @@
+$(function(){
+  $('#new_comment').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false,
+    })
+  })
+})

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,4 +1,8 @@
 $(function(){
+  function buildHTML(comment){
+    var html = `<p>${comment.text}</p>`
+    return html;
+  }
   $('#new_comment').on('submit', function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -11,5 +15,15 @@ $(function(){
       processData: false,
       contentType: false,
     })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.comments__list').append(html);
+      $('.textbox').val('');
+      $('.comment__textbox').val('');
+      $('.form__button').prop('disabled', false);
+    })
+    .fall(function(){
+      alert('error');
+    })
   })
-})
+});

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,6 +1,6 @@
 $(function(){
   function buildHTML(comment){
-    var html = `<p>${comment.text}</p>`
+    var html = `<p class="comment__text">${comment.text}</p>`
     return html;
   }
   $('#new_comment').on('submit', function(e){

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -101,7 +101,7 @@
       font-size: 16px;
     }
     #comment_text {
-      width: 522px;
+      width: 100%;
       height: 25px;
     }
     .form__button {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,8 @@ class CommentsController < ApplicationController
     event = Event.find(params[:event_id])
     @comment = event.comments.build(comment_params)
     if @comment.save
-      redirect_to event_path(params[:event_id])
+      respond_to do |format|
+        format.json
     else
       redirect_to event_path(params[:event_id])
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,7 @@ class CommentsController < ApplicationController
     if @comment.save
       respond_to do |format|
         format.json
+      end
     else
       redirect_to event_path(params[:event_id])
     end

--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.text @comment.text

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -48,7 +48,7 @@
   <%= form_with(model: [@event, Comment.new], local: true, id: "new_comment") do |form| %>
     <div class="comment__form">
       <%= form.label :コメントを書く, class: 'comment__label' %>
-      <%= form.text_field :text %>
+      <%= form.text_field :text, class: "comment__textbox" %>
       <%= button_tag type: 'submit', class: 'form__button' do %>
         コメントする
       <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -45,7 +45,7 @@
         <%= link_to 'トップページにもどる', events_path, class: 'top__link-show' %>
       </div>
   </div>
-  <%= form_with(model: [@event, Comment.new], local: true) do |form| %>
+  <%= form_with(model: [@event, Comment.new], local: true, id: "new_comment") do |form| %>
     <div class="comment__form">
       <%= form.label :コメントを書く, class: 'comment__label' %>
       <%= form.text_field :text %>


### PR DESCRIPTION
# What
コメントの非同期通信の実装
# Why
コメントが送信される度にブラウザが再読み込みされずにコメントを表示できる方がストレスなく見られるため。